### PR TITLE
testing/bsps: add configuration for rv64xcheri_qemu

### DIFF
--- a/tester/rtems/testing/bsps/rv64xcheri_qemu.ini
+++ b/tester/rtems/testing/bsps/rv64xcheri_qemu.ini
@@ -1,6 +1,6 @@
 #
 # RTEMS Tools Project (http://www.rtems.org/)
-# Copyright 2010-2014 Chris Johns (chrisj@rtems.org)
+# Copyright 2020 Vijay Kumar Banerjee (vijay@rtems.org)
 # All rights reserved.
 #
 # This file is part of the RTEMS Tools package in 'rtems-tools'.
@@ -29,60 +29,11 @@
 #
 
 #
-# QEMU
+# RISC-V CHERI BSP
 #
-# Use a qemu command to run the executable in the qemu simulator.
-#
-
-%include %{_configdir}/base.cfg
-%include %{_configdir}/checks.cfg
-
-#
-# Console.
-#
-%define console_stdio
-%include %{_configdir}/console.cfg
-
-#
-# RTEMS version
-#
-%include %{_rtdir}/rtems/version.cfg
-
-#
-# Coverage, some builds of qemu support coverage.
-#
-%if %{defined coverage}
- %define qemu_use_serial_console
-%endif
-
-#
-# Qemu common option patterns.
-#
-%if %{defined qemu_use_serial_console}
- %define qemu_opts_base -no-reboot -monitor none -serial stdio -nographic
-%else
- %define qemu_opts_base -no-reboot -serial null -serial mon:stdio -nographic
-%endif
-%define qemu_opts_no_net -net none
-
-#
-# Qemu executable
-#
-%ifn %{defined bsp_qemu_opts}
- %define bsp_qemu_opts %{nil}
-%endif
-%ifn %{defined bsp_qemu_cov_opts}
- %define bsp_qemu_cov_opts %{nil}
-%endif
-
-%define qemu_cmd  qemu-system-%{bsp_arch}
-%define qemu_opts %{bsp_qemu_opts} %{bsp_qemu_cov_opts}
-
-#
-# Executable
-#
-%ifn %{defined qemu_mode}
- %define qemu_mode -kernel
-%endif
-
-%execute %{qemu_cmd} %{qemu_opts} %{qemu_mode} %{test_executable}
+[rv64xcheri_qemu]
+bsp           = rv64xcheri_qemu
+arch          = riscv64cheri
+tester        = %{_rtscripts}/qemu.cfg
+qemu_mode     = -bios
+bsp_qemu_opts = -no-reboot -nographic -net none -machine virt -m 128M


### PR DESCRIPTION
Tested this on rtems-rtems-riscv64-purecap target from cheribuild.py and double-checked that the -bios option is supported by the qemu version built by RTEMS-source-builder.